### PR TITLE
make 'kompose' friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+*devops-secret-secret.yaml

--- a/Customer360/docker-compose.yaml
+++ b/Customer360/docker-compose.yaml
@@ -1,50 +1,62 @@
-version: "3"
+version: "3.5"
 
 services:
   pingfederate:
     image: pingidentity/pingfederate:latest
     command: wait-for pingdirectory:389 -t 300 -- entrypoint.sh start-server
     env_file:
-      - ~/.pingidentity/devops
       - ./env_vars
+    secrets:
+      - devops-secret
     environment:
+    - PING_IDENTITY_DEVOPS_FILE=devops-secret
     - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-solution-stacks.git
     - SERVER_PROFILE_PATH=Customer360/pingfederate
-    #volumes:
+    # volumes:
     #  - ${HOME}/projects/devops/volumes/full-stack.pingfederate:/opt/out
     #  - ${HOME}/projects/devops/pingidentity-server-profiles/baseline/pingfederate:/opt/in
-    ports:
-      - 9031:9031
-      - 9999:9999
-    networks:
-      - pingnet-internal
-      - pingnet-dmz
+    ## uncomment when using kompose
+    expose:
+      - 9031
+      - 9999
+    ## comment this when using kompose 
+    # ports:
+    #   - 9031:9031
+    #   - 9999:9999
 
   pingdirectory:
     image: pingidentity/pingdirectory:latest
     env_file:
-      - ~/.pingidentity/devops
       - ./env_vars
+    secrets:
+      - ${HOME}/.pingidentity/devops
     environment:
+    - PING_IDENTITY_DEVOPS_FILE=devops-secret
     - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-solution-stacks.git
     - SERVER_PROFILE_PATH=Customer360/pingdirectory
     #volumes:
     #  - ${HOME}/projects/devops/volumes/full-stack.pingdirectory:/opt/out
     #  - ${HOME}/projects/devops/pingidentity-server-profiles/baseline/pingdirectory:/opt/in
+    ## uncomment when using kompose
+    expose:
+      - 636
+      - 443
+    ## comment this when using kompose
     ports:
       - 1636:636
       - 1443:443
-    networks:
-      - pingnet-internal
+
 
   pingdatasync:
     image: pingidentity/pingdatasync:latest
     environment:
+      - PING_IDENTITY_DEVOPS_FILE=devops-secret
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-solution-stacks.git
       - SERVER_PROFILE_PATH=Customer360/pingdatasync
     env_file:
-      - ~/.pingidentity/devops
       - ./env_vars
+    secrets:
+      - ${HOME}/.pingidentity/devops
     #volumes:
     #   - ${HOME}/projects/devops/volumes/simple-sync.pingdatasync:/opt/out
     ulimits:
@@ -54,19 +66,25 @@ services:
       nofile:
         soft: 65535
         hard: 65535
+    ## uncomment when using kompose
+    # expose:
+    #   - 636
+    #   - 443
+    ## comment this when using kompose
     ports:
       - 3636:636
       - 3443:443
-    networks:
-      - pingnet-internal
   
   pingdataconsole:
     image: pingidentity/pingdataconsole:latest
+    ## uncomment when using kompose
+    # expose:
+    #   - 8080
+    #   - 8443
+    ## comment this when using kompose
     ports:
       - 8080:8080
       - 8443:8443
-    networks: 
-      - pingnet-internal
 
   pingconfig:
     image: pricecs/pingconfigurator
@@ -76,9 +94,7 @@ services:
     volumes: 
       # An environment file should be injected into the image - this file should contain your specfic info and secrets
       - ./postman_vars.json:/usr/src/app/postman_vars.json
-    networks:
-      - pingnet-internal
 
-networks:
-    pingnet-internal:
-    pingnet-dmz:
+secrets:
+  devops-secret:
+    file: ${HOME}/.pingidentity/devops


### PR DESCRIPTION
suggesting some features to make the tool kompose work better:
- comment out port maps, and use expose ports instead so it maps better on k8s services. 
- use a Docker secret instead of mounting devops file so devops creds aren't shown in the cluster. 
- add to .gitignore to prevent accidental storing personal devops creds. 
> note: using devops-secret does require creating the secret in k8s. 
you can keep a template devops-secret in the repo. or just point to https://pingidentity-devops.gitbook.io/devops/getstarted/devopsuserkey#for-kubernetes for docs on how to create. *easy*